### PR TITLE
Retrieve and Batch Size

### DIFF
--- a/SalesforceMagic.sln
+++ b/SalesforceMagic.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.30501.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SalesforceMagic", "SalesforceMagic\SalesforceMagic.csproj", "{2B4E24AE-F8EE-4585-92E7-90CF45982CC2}"
 EndProject
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{292126
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApplication1", "ConsoleApplication1\ConsoleApplication1.csproj", "{6DB8C432-04FD-4D30-8F23-344610E6BC3F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SalesforceMagicTests", "SalesforceMagicTests\SalesforceMagicTests.csproj", "{E2379DF3-12E1-4E5E-98C4-2C3A79890F01}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,6 +30,10 @@ Global
 		{6DB8C432-04FD-4D30-8F23-344610E6BC3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6DB8C432-04FD-4D30-8F23-344610E6BC3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6DB8C432-04FD-4D30-8F23-344610E6BC3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2379DF3-12E1-4E5E-98C4-2C3A79890F01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2379DF3-12E1-4E5E-98C4-2C3A79890F01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2379DF3-12E1-4E5E-98C4-2C3A79890F01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2379DF3-12E1-4E5E-98C4-2C3A79890F01}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SalesforceMagic/Abstract/ISalesforceClient.cs
+++ b/SalesforceMagic/Abstract/ISalesforceClient.cs
@@ -66,7 +66,7 @@ namespace SalesforceMagic.Abstract
         /// <typeparam name="T"></typeparam>
         /// <param name="query"></param>
         /// <returns></returns>
-        IEnumerable<T> Query<T>(string query);
+        IEnumerable<T> Query<T>(string query) where T : SObject;
 
         /// <summary>
         ///     Advanced Query
@@ -102,7 +102,7 @@ namespace SalesforceMagic.Abstract
         /// <typeparam name="T"></typeparam>
         /// <param name="query"></param>
         /// <returns></returns>
-        QueryResult<T> AdvancedQuery<T>(string query);
+        QueryResult<T> AdvancedQuery<T>(string query) where T : SObject;
 
         /// <summary>
         ///     Query More
@@ -112,7 +112,7 @@ namespace SalesforceMagic.Abstract
         /// <typeparam name="T"></typeparam>
         /// <param name="queryLocator"></param>
         /// <returns></returns>
-        QueryResult<T> QueryMore<T>(string queryLocator);
+        QueryResult<T> QueryMore<T>(string queryLocator) where T : SObject;
 
         /// <summary>
         ///     Query Single
@@ -132,7 +132,7 @@ namespace SalesforceMagic.Abstract
         /// <typeparam name="T"></typeparam>
         /// <param name="query"></param>
         /// <returns></returns>
-        T QuerySingle<T>(string query);
+        T QuerySingle<T>(string query) where T : SObject;
 
         #endregion
 

--- a/SalesforceMagic/Configuration/SalesforceConfig.cs
+++ b/SalesforceMagic/Configuration/SalesforceConfig.cs
@@ -15,5 +15,10 @@ namespace SalesforceMagic.Configuration
         public string ApiVersion { get; set; }
         public string InstanceUrl { get; set; }
         public WebProxy Proxy { get; set; }
+
+        /// <summary>
+        /// Min: 200, Max: 2000, Default: 500.
+        /// </summary>
+        public int? BatchSize { get; set; }
     }
 }

--- a/SalesforceMagic/Configuration/SalesforceSession.cs
+++ b/SalesforceMagic/Configuration/SalesforceSession.cs
@@ -12,5 +12,10 @@ namespace SalesforceMagic.Configuration
         public string ApiVersion { get; set; }
         public DateTime LastLogin { get; set; }
         public WebProxy Proxy { get; set; }
+
+        /// <summary>
+        /// Min: 200, Max: 2000, Default: 500.
+        /// </summary>
+        public int? BatchSize { get; set; }
     }
 }

--- a/SalesforceMagic/Http/XmlRequestGenerator.cs
+++ b/SalesforceMagic/Http/XmlRequestGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using System.Xml;
 using System.Xml.Serialization;
-using SalesforceMagic.BulkApi.RequestTemplates;
 using SalesforceMagic.ORM.BaseRequestTemplates;
 
 namespace SalesforceMagic.Http

--- a/SalesforceMagic/ORM/BaseRequestTemplates/SessionHeader.cs
+++ b/SalesforceMagic/ORM/BaseRequestTemplates/SessionHeader.cs
@@ -9,4 +9,11 @@ namespace SalesforceMagic.ORM.BaseRequestTemplates
         [XmlElement("sessionId", Namespace = SalesforceNamespaces.SalesforceRequest)]
         public string SessionId { get; set; } 
     }
+
+    [Serializable]
+    public class QueryOptionsHeader
+    {
+        [XmlElement("batchSize", Namespace = SalesforceNamespaces.SalesforceRequest)]
+        public int BatchSize { get; set; } 
+    }
 }

--- a/SalesforceMagic/ORM/BaseRequestTemplates/XmlHeader.cs
+++ b/SalesforceMagic/ORM/BaseRequestTemplates/XmlHeader.cs
@@ -8,5 +8,8 @@ namespace SalesforceMagic.ORM.BaseRequestTemplates
     {
         [XmlElement("SessionHeader", Namespace = SalesforceNamespaces.SalesforceRequest)]
         public SessionHeader SessionHeader { get; set; }
+
+        [XmlElement("QueryOptions", Namespace = SalesforceNamespaces.SalesforceRequest)]
+        public QueryOptionsHeader QueryOptions { get; set; }
     }
 }

--- a/SalesforceMagic/ORM/ResponseReader.cs
+++ b/SalesforceMagic/ORM/ResponseReader.cs
@@ -129,7 +129,11 @@ namespace SalesforceMagic.ORM
         {
             return (from XmlNode node in GetNamedNodes(document, "records") select ReadSimpleResponse<T>(node, document)).ToArray();
         }
-        
+
+        internal static T[] ReadRetriveResponse<T>(XmlDocument document)
+        {
+            return (from XmlNode node in GetNamedNodes(document, "result") select ReadSimpleResponse<T>(node, document)).ToArray();
+        }
 
         public static QueryResult<T> ReadQueryResponse<T>(XmlDocument document)
         {

--- a/SalesforceMagic/ORM/ResponseReader.cs
+++ b/SalesforceMagic/ORM/ResponseReader.cs
@@ -130,9 +130,9 @@ namespace SalesforceMagic.ORM
             return (from XmlNode node in GetNamedNodes(document, "records") select ReadSimpleResponse<T>(node, document)).ToArray();
         }
 
-        internal static T[] ReadRetriveResponse<T>(XmlDocument document)
+        internal static T[] ReadRetriveResponse<T>(XmlDocument document) where T : SObject
         {
-            return (from XmlNode node in GetNamedNodes(document, "result") select ReadSimpleResponse<T>(node, document)).ToArray();
+            return (from XmlNode node in GetNamedNodes(document, "result") select ReadSimpleResponse<T>(node, document)).Select(r => r.Id == null ? null : r).ToArray();
         }
 
         public static QueryResult<T> ReadQueryResponse<T>(XmlDocument document)

--- a/SalesforceMagic/SalesforceClient.cs
+++ b/SalesforceMagic/SalesforceClient.cs
@@ -152,7 +152,7 @@ namespace SalesforceMagic
         /// <typeparam name="T"></typeparam>
         /// <param name="query"></param>
         /// <returns></returns>
-        public virtual IEnumerable<T> Query<T>(string query)
+        public virtual IEnumerable<T> Query<T>(string query) where T : SObject
         {
             // TODO: Validate query
             return PerformArrayRequest<T>(SoapRequestManager.GetQueryRequest(query, Login()));
@@ -198,7 +198,7 @@ namespace SalesforceMagic
         /// <typeparam name="T"></typeparam>
         /// <param name="query"></param>
         /// <returns></returns>
-        public QueryResult<T> AdvancedQuery<T>(string query)
+        public QueryResult<T> AdvancedQuery<T>(string query) where T : SObject
         {
             return PerformQueryRequest<T>(SoapRequestManager.GetQueryRequest(query, Login()));
         }
@@ -211,7 +211,7 @@ namespace SalesforceMagic
         /// <typeparam name="T"></typeparam>
         /// <param name="queryLocator"></param>
         /// <returns></returns>
-        public QueryResult<T> QueryMore<T>(string queryLocator)
+        public QueryResult<T> QueryMore<T>(string queryLocator) where T : SObject
         {
             return PerformQueryRequest<T>(SoapRequestManager.GetQueryMoreRequest(queryLocator, Login()));
         }
@@ -221,7 +221,7 @@ namespace SalesforceMagic
             return Query(predicate).FirstOrDefault();
         }
 
-        public virtual T QuerySingle<T>(string query)
+        public virtual T QuerySingle<T>(string query) where T : SObject
         {
             return Query<T>(query).FirstOrDefault();
         }
@@ -377,7 +377,7 @@ namespace SalesforceMagic
             }
         }
 
-        private IEnumerable<T> PerformArrayRequest<T>(HttpRequest request)
+        private IEnumerable<T> PerformArrayRequest<T>(HttpRequest request) where T : SObject
         {
             using (HttpClient httpClient = new HttpClient())
             {
@@ -386,7 +386,7 @@ namespace SalesforceMagic
             }
         }
 
-        private IEnumerable<T> PerformRetrieveRequest<T>(HttpRequest request)
+        private IEnumerable<T> PerformRetrieveRequest<T>(HttpRequest request) where T : SObject
         {
             using (HttpClient httpClient = new HttpClient())
             {
@@ -395,7 +395,7 @@ namespace SalesforceMagic
             }
         }
 
-        private QueryResult<T> PerformQueryRequest<T>(HttpRequest request)
+        private QueryResult<T> PerformQueryRequest<T>(HttpRequest request) where T : SObject
         {
             using (HttpClient httpClient = new HttpClient())
             {

--- a/SalesforceMagic/SalesforceMagic.csproj
+++ b/SalesforceMagic/SalesforceMagic.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ORM\ResponseReader.cs" />
     <Compile Include="SoapApi\Enum\CrudOperations.cs" />
     <Compile Include="SoapApi\RequestTemplates\QueryMoreTemplate.cs" />
+    <Compile Include="SoapApi\RequestTemplates\RetrieveTemplate.cs" />
     <Compile Include="SoapApi\RequestTemplates\UpsertTemplate.cs" />
     <Compile Include="SoapApi\RequestTemplates\DeleteTemplate.cs" />
     <Compile Include="SoapApi\RequestTemplates\CrudTemplate.cs" />

--- a/SalesforceMagic/SoapApi/RequestTemplates/RetrieveTemplate.cs
+++ b/SalesforceMagic/SoapApi/RequestTemplates/RetrieveTemplate.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Xml.Serialization;
+using SalesforceMagic.Extensions;
+using SalesforceMagic.ORM.BaseRequestTemplates;
+
+namespace SalesforceMagic.SoapApi.RequestTemplates
+{
+    [Serializable]
+    public class RetrieveTemplate
+    {
+        [XmlIgnore]
+        public Type Type { get; set; }
+
+        [XmlElement("fieldList", Namespace = SalesforceNamespaces.SalesforceRequest)]
+        public string FieldList 
+        {
+            get { return string.Join(", ", Type.GetPropertyNames(true)); }
+            set { }  // Apparently this is needed for XML serialization...
+        }
+
+        [XmlElement("sObjectType", Namespace = SalesforceNamespaces.SalesforceRequest)]
+        public string SObjectType 
+        {
+            get { return Type.GetName(); }
+            set { }  // Apparently this is needed for XML serialization...
+        }
+
+        [XmlElement("ids", Namespace = SalesforceNamespaces.SalesforceRequest)]
+        public string[] Ids { get; set; }
+    }
+}

--- a/SalesforceMagic/SoapApi/RequestTemplates/XmlBody.cs
+++ b/SalesforceMagic/SoapApi/RequestTemplates/XmlBody.cs
@@ -1,6 +1,4 @@
-﻿using System.Xml;
-using System.Xml.Schema;
-using System.Xml.Serialization;
+﻿using System.Xml.Serialization;
 using SalesforceMagic.SoapApi.RequestTemplates;
 
 namespace SalesforceMagic.ORM.BaseRequestTemplates
@@ -27,5 +25,8 @@ namespace SalesforceMagic.ORM.BaseRequestTemplates
 
         [XmlElement("delete", Namespace = SalesforceNamespaces.SalesforceRequest)]
         public DeleteTemplate DeleteTemplate { get; set; }
+
+        [XmlElement("retrieve", Namespace = SalesforceNamespaces.SalesforceRequest)]
+        public RetrieveTemplate RetrieveTemplate { get; set; }
     }
 }

--- a/SalesforceMagic/SoapApi/SoapRequestManager.cs
+++ b/SalesforceMagic/SoapApi/SoapRequestManager.cs
@@ -48,7 +48,7 @@ namespace SalesforceMagic.SoapApi
             HttpRequest request = new HttpRequest
             {
                 Url = GetSoapUrl(session.InstanceUrl, session.ApiVersion),
-                Body = SoapCommands.Query(query, session.SessionId),
+                Body = SoapCommands.Query(query, session),
                 Method = RequestType.POST,
                 Proxy = session.Proxy
             };
@@ -62,7 +62,7 @@ namespace SalesforceMagic.SoapApi
             HttpRequest request = new HttpRequest
             {
                 Url = GetSoapUrl(session.InstanceUrl, session.ApiVersion),
-                Body = SoapCommands.QueryMore(queryLocator, session.SessionId),
+                Body = SoapCommands.QueryMore(queryLocator, session),
                 Method = RequestType.POST,
                 Proxy = session.Proxy
             };
@@ -71,9 +71,24 @@ namespace SalesforceMagic.SoapApi
             return request;
         }
 
+        internal static HttpRequest GetRetrieveRequest<T>(string[] ids, SalesforceSession session) where T : SObject
+        {
+            string body = SoapCommands.Retrieve<T>(ids, session);
+            HttpRequest request = new HttpRequest
+            {
+                Url = GetSoapUrl(session.InstanceUrl, session.ApiVersion),
+                Body = body,
+                Method = RequestType.POST,
+                Proxy = session.Proxy
+            };
+            request.Headers.Add("SOAPAction", "retrieve");
+
+            return request;
+        }
+
         internal static HttpRequest GetCrudRequest<T>(CrudOperation<T> operation, SalesforceSession session) where T : SObject
         {
-            string body = SoapCommands.CrudOperation(operation, session.SessionId);
+            string body = SoapCommands.CrudOperation(operation, session);
             HttpRequest request = new HttpRequest
             {
                 Url = GetSoapUrl(session.InstanceUrl, session.ApiVersion),

--- a/SalesforceMagicTests/SoqlVisitorTests.cs
+++ b/SalesforceMagicTests/SoqlVisitorTests.cs
@@ -18,6 +18,10 @@ namespace SalesforceMagicTests
             TestExpression(a => a.IsDeleted != true).ShouldBe("IsDeleted != True");
             TestExpression(a => a.IsDeleted == false).ShouldBe("IsDeleted = False");
             TestExpression(a => a.IsDeleted != false).ShouldBe("IsDeleted != False");
+
+            TestExpression(a => !a.IsDeleted && !a.IsClosed).ShouldBe("IsDeleted != True AND IsClosed != True");
+            TestExpression(a => !a.IsDeleted && a.Id == "034687OAEB").ShouldBe("IsDeleted != True AND Id = '034687OAEB'");
+            TestExpression(a => a.Id == "034687OAEB" && !a.IsDeleted).ShouldBe("Id = '034687OAEB' AND IsDeleted != True");
         }
 
         private string TestExpression(Expression<Func<TestAccount, bool>> expression)
@@ -27,7 +31,11 @@ namespace SalesforceMagicTests
 
         private class TestAccount
         {
+            public string Id { get; set; }
+
             public bool IsDeleted { get; set; }
+
+            public bool IsClosed { get; set; }
         }
     }
 }


### PR DESCRIPTION
This pull request adds capability for the 'retrieve' SOAP API, to allow for retrieving of an object based on id, including automating filling of an SObject.

Included also is the ability to specify the batch size for queries at the config or session level. This is important if you want to configure your pagesize on queries.

Also includes a few minor improvements and minor refactoring of SoapCommands.cs.

Please let me know if you would like me to do anything differently!
Ben