### PR TITLE
Modified SalesforceClient, HttpClient and API default version.

### DIFF
--- a/SalesforceMagic/Abstract/ISalesforceClient.cs
+++ b/SalesforceMagic/Abstract/ISalesforceClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Net;
 using SalesforceMagic.BulkApi.Configuration;
 using SalesforceMagic.BulkApi.Models;
 using SalesforceMagic.Configuration;
@@ -12,7 +13,7 @@ namespace SalesforceMagic.Abstract
     {
         #region Utility Methods
 
-        void ChangeEnvironment(SalesforceConfig config, bool login = false);
+        void ChangeEnvironment(SalesforceConfig config, bool login = false, SecurityProtocolType securityProtocol = SecurityProtocolType.Tls11);
         string GetSessionId();
         SalesforceSession GetSession();
         SalesforceSession Login();

--- a/SalesforceMagic/BulkApi/BulkRequestManager.cs
+++ b/SalesforceMagic/BulkApi/BulkRequestManager.cs
@@ -10,7 +10,7 @@ namespace SalesforceMagic.BulkApi
 {
     internal static class BulkRequestManager
     {
-        internal static string DefaultApiVersion = "30.0";
+        internal static string DefaultApiVersion = "38.0";
         internal static string BulkApiUrl = "/services/async/";
 
         public static HttpRequest GetStartJobRequest<T>(JobConfig config, SalesforceSession session)

--- a/SalesforceMagic/Http/HttpClient.cs
+++ b/SalesforceMagic/Http/HttpClient.cs
@@ -158,15 +158,6 @@ namespace SalesforceMagic.Http
                 return;
             }
 
-            if (disposing)
-            {
-                // Free any other managed objects here.
-                //
-            }
-
-            // Free any unmanaged objects here.
-            //
-
             this.disposed = true;
         }
 

--- a/SalesforceMagic/SalesforceClient.cs
+++ b/SalesforceMagic/SalesforceClient.cs
@@ -33,22 +33,20 @@ namespace SalesforceMagic
         private static readonly object Lock = new object();
         #endregion
 
-        public SalesforceClient(ISessionStoreProvider sessionStore, SalesforceConfig config, bool login = false)
+        public SalesforceClient(ISessionStoreProvider sessionStore, SalesforceConfig config, bool login = false, SecurityProtocolType securityProtocol = SecurityProtocolType.Tls11)
         {
             _sessionStore = sessionStore;
-            _config = config;
-            if (login) Login();
+            this.ChangeEnvironment(config, login, securityProtocol);
         }
 
-        public SalesforceClient(SalesforceConfig config, bool login = false)
+        public SalesforceClient(SalesforceConfig config, bool login = false, SecurityProtocolType securityProtocol = SecurityProtocolType.Tls11)
+            : this(new MemoryCacheProvider(), config, login)
         {
-            _sessionStore = new MemoryCacheProvider();
-            _config = config;
-            if (login) Login();
         }
 
-        public virtual void ChangeEnvironment(SalesforceConfig config, bool login = false)
+        public virtual void ChangeEnvironment(SalesforceConfig config, bool login = false, SecurityProtocolType securityProtocol = SecurityProtocolType.Tls11)
         {
+            ServicePointManager.SecurityProtocol = securityProtocol;
             _config = config;
             if (login) Login();
         }
@@ -65,8 +63,6 @@ namespace SalesforceMagic
 
         public SalesforceSession Login()
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-
             lock (Lock)
             {
                 SalesforceSession session;

--- a/SalesforceMagic/SalesforceClient.cs
+++ b/SalesforceMagic/SalesforceClient.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Net;
 using System.Xml;
 using SalesforceMagic.Abstract;
 using SalesforceMagic.BulkApi;
@@ -64,6 +65,8 @@ namespace SalesforceMagic
 
         public SalesforceSession Login()
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             lock (Lock)
             {
                 SalesforceSession session;

--- a/SalesforceMagic/SalesforceClient.cs
+++ b/SalesforceMagic/SalesforceClient.cs
@@ -40,7 +40,7 @@ namespace SalesforceMagic
         }
 
         public SalesforceClient(SalesforceConfig config, bool login = false, SecurityProtocolType securityProtocol = SecurityProtocolType.Tls11)
-            : this(new MemoryCacheProvider(), config, login)
+            : this(new MemoryCacheProvider(), config, login, securityProtocol)
         {
         }
 

--- a/SalesforceMagic/SoapApi/SoapRequestManager.cs
+++ b/SalesforceMagic/SoapApi/SoapRequestManager.cs
@@ -10,7 +10,7 @@ namespace SalesforceMagic.SoapApi
 {
     internal class SoapRequestManager
     {
-        internal static string DefaultApiVersion = "30.0";
+        internal static string DefaultApiVersion = "38.0";
         internal static string SoapUrl = "/services/Soap/";
 
         internal static HttpRequest GetLoginRequest(SalesforceConfig config)


### PR DESCRIPTION
**SalesforceClient**: used SecurityProtocolType.Tls12 as TLS 1.0 is not accepted anymore by Salesforce.
**HttpClient**: removed several using blocks that swallow exception traces + implemented IDisposable pattern.
Soap and Bulk request managers: **API default version** set to 38.0.